### PR TITLE
Dev/fix session ownership

### DIFF
--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -19,13 +19,15 @@
 namespace kdr {
 
 struct engine_t final {
-  using ioc_t = boost::asio::io_context;
   using ssl_context_t = boost::asio::ssl::context;
 
   using recv_cb_t = session_t::recv_cb_t;
 
-  engine_t(ioc_t &ioc, ssl_context_t &ssl_context, const config_t &config,
+  engine_t(ssl_context_t &ssl_context, const config_t &config,
            const sink_t &sink);
+
+  const session_t &session() const { return m_session; }
+  session_t &session() { return m_session; }
 
   void start_processing(const recv_cb_t &cb) { m_session.start_processing(cb); }
   bool keep_processing() const { return m_session.keep_processing(); }

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -19,7 +19,17 @@
 namespace kdr {
 
 struct engine_t final {
-  engine_t(session_t &, const config_t &, const sink_t &);
+  using ioc_t = boost::asio::io_context;
+  using ssl_context_t = boost::asio::ssl::context;
+
+  using recv_cb_t = session_t::recv_cb_t;
+
+  engine_t(ioc_t &ioc, ssl_context_t &ssl_context, const config_t &config,
+           const sink_t &sink);
+
+  void start_processing(const recv_cb_t &cb) { m_session.start_processing(cb); }
+  bool keep_processing() const { return m_session.keep_processing(); }
+  void stop_processing() { m_session.stop_processing(); }
 
   /** Return false to cease processing and shut down. */
   bool handle_msg(msg_t);
@@ -37,7 +47,7 @@ private:
   bool handle_heartbeat_msg(doc_t &);
   bool handle_pong_msg(doc_t &);
 
-  session_t &m_session;
+  session_t m_session;
   config_t m_config;
 
   simdjson::ondemand::parser m_parser;

--- a/include/session.hpp
+++ b/include/session.hpp
@@ -32,7 +32,7 @@ struct session_t final {
 
   using recv_cb_t = std::function<bool(msg_t)>;
 
-  session_t(ioc_t &, ssl_context_t &, const config_t &);
+  session_t(ioc_t &ioc, ssl_context_t &ssl_context, const config_t &config);
 
   bool keep_processing() const { return m_keep_processing; }
   void start_processing(const recv_cb_t &);

--- a/include/session.hpp
+++ b/include/session.hpp
@@ -32,7 +32,13 @@ struct session_t final {
 
   using recv_cb_t = std::function<bool(msg_t)>;
 
-  session_t(ioc_t &ioc, ssl_context_t &ssl_context, const config_t &config);
+  session_t(ssl_context_t &ssl_context, const config_t &config);
+
+  session_t(const session_t &rhs) = delete;
+  session_t operator=(const session_t &rhs) = delete;
+
+  const ioc_t &ioc() const { return m_ioc; }
+  ioc_t &ioc() { return m_ioc; }
 
   bool keep_processing() const { return m_keep_processing; }
   void start_processing(const recv_cb_t &);
@@ -60,7 +66,7 @@ private:
   void on_read(error_code, size_t);
   void on_close(error_code);
 
-  ioc_t &m_ioc;
+  ioc_t m_ioc;
   resolver m_resolver;
   websocket_t m_ws;
   boost::asio::deadline_timer m_ping_timer;

--- a/kdr_record/kdr_record.cpp
+++ b/kdr_record/kdr_record.cpp
@@ -5,7 +5,6 @@
 #include "engine.hpp"
 #include "level_book.hpp"
 #include "pairs_sink.hpp"
-#include "session.hpp"
 #include "sink.hpp"
 #include "trade_sink.hpp"
 #include "types.hpp"
@@ -136,8 +135,7 @@ int main(int argc, char *argv[]) {
             ? kdr::sink_t::accept_trades_t{accept_trades}
             : kdr::sink_t::accept_trades_t{noop_accept_trades}};
 
-    auto session = kdr::session_t(ioc, ctx, config);
-    auto engine = kdr::engine_t(session, config, sink);
+    auto engine = kdr::engine_t(ioc, ctx, config, sink);
 
     const auto handle_recv = [&engine](kdr::msg_t msg) {
       try {
@@ -147,13 +145,13 @@ int main(int argc, char *argv[]) {
         return false;
       }
     };
-    session.start_processing(handle_recv);
+    engine.start_processing(handle_recv);
 
-    while (!shutting_down && session.keep_processing()) {
+    while (!shutting_down && engine.keep_processing()) {
       ioc.run_one();
     }
     BOOST_LOG_TRIVIAL(error) << "session.stop_processing()";
-    session.stop_processing();
+    engine.stop_processing();
   } catch (const std::exception &ex) {
     ioc.stop();
     BOOST_LOG_TRIVIAL(error) << ex.what();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -14,9 +14,9 @@
 
 namespace kdr {
 
-engine_t::engine_t(session_t &session, const config_t &config,
-                   const sink_t &sink)
-    : m_session{session}, m_config{config}, m_sink(sink) {}
+engine_t::engine_t(ioc_t &ioc, ssl_context_t &ssl_context,
+                   const config_t &config, const sink_t &sink)
+    : m_session{ioc, ssl_context, config}, m_config{config}, m_sink(sink) {}
 
 bool engine_t::handle_msg(msg_t msg) {
   m_metrics.accept(msg);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -14,9 +14,9 @@
 
 namespace kdr {
 
-engine_t::engine_t(ioc_t &ioc, ssl_context_t &ssl_context,
-                   const config_t &config, const sink_t &sink)
-    : m_session{ioc, ssl_context, config}, m_config{config}, m_sink(sink) {}
+engine_t::engine_t(ssl_context_t &ssl_context, const config_t &config,
+                   const sink_t &sink)
+    : m_session{ssl_context, config}, m_config{config}, m_sink(sink) {}
 
 bool engine_t::handle_msg(msg_t msg) {
   m_metrics.accept(msg);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -14,10 +14,9 @@ namespace ws = bst::websocket;
 
 namespace kdr {
 
-session_t::session_t(ioc_t &ioc, ssl_context_t &ssl_context,
-                     const config_t &config)
-    : m_ioc{ioc}, m_resolver{m_ioc}, m_ws{ioc, ssl_context},
-      m_ping_timer{m_ioc}, m_config{config} {
+session_t::session_t(ssl_context_t &ssl_context, const config_t &config)
+    : m_resolver{m_ioc}, m_ws{m_ioc, ssl_context}, m_ping_timer{m_ioc},
+      m_config{config} {
   if (m_config.ping_interval_secs() < 1) {
     BOOST_LOG_TRIVIAL(error)
         << __FUNCTION__


### PR DESCRIPTION
Restructured to eliminate reference members:
- session_t now owns the boost io context
- engine_t now owns session_t
