### PR TITLE
Dev/improve-session-and-engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(kdr
   include/instrument.hpp
   include/level_book.hpp
   include/refdata.hpp
+  include/sides.hpp
   include/sink.hpp
   include/timestamp.hpp
   include/trades.hpp
@@ -136,6 +137,7 @@ add_library(kdr
   src/refdata.cpp
   src/requests.cpp
   src/session.cpp
+  src/sides.cpp
   src/trades.cpp
 )
 add_dependencies(kdr generate_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(simdjson)
 set(MODEL_FILES
   ${CMAKE_SOURCE_DIR}/model/asset.json
   ${CMAKE_SOURCE_DIR}/model/pair.json
+  ${CMAKE_SOURCE_DIR}/model/pong.json
   ${CMAKE_SOURCE_DIR}/model/trade.json
 )
 
@@ -42,6 +43,7 @@ set(GENERATED_FILES
   ${CMAKE_SOURCE_DIR}/include/generated/ord_type.hpp
   ${CMAKE_SOURCE_DIR}/include/generated/pair.hpp
   ${CMAKE_SOURCE_DIR}/include/generated/pair_status.hpp
+  ${CMAKE_SOURCE_DIR}/include/generated/pong.hpp
   ${CMAKE_SOURCE_DIR}/include/generated/side.hpp
   ${CMAKE_SOURCE_DIR}/include/generated/trade.hpp
   ${CMAKE_SOURCE_DIR}/src/generated/asset.cpp
@@ -50,6 +52,7 @@ set(GENERATED_FILES
   ${CMAKE_SOURCE_DIR}/src/generated/ord_type.cpp
   ${CMAKE_SOURCE_DIR}/src/generated/pair.cpp
   ${CMAKE_SOURCE_DIR}/src/generated/pair_status.cpp
+  ${CMAKE_SOURCE_DIR}/src/generated/pong.cpp
   ${CMAKE_SOURCE_DIR}/src/generated/side.cpp
   ${CMAKE_SOURCE_DIR}/src/generated/trade.cpp
 )
@@ -102,6 +105,7 @@ add_library(kdr
   include/generated/depth.hpp
   include/generated/ord_type.hpp
   include/generated/pair.hpp
+  include/generated/pong.hpp
   include/generated/pair_status.hpp
   include/generated/side.hpp
   include/generated/trade.hpp
@@ -111,6 +115,7 @@ add_library(kdr
   src/generated/ord_type.cpp
   src/generated/pair.cpp
   src/generated/pair_status.cpp
+  src/generated/pong.cpp
   src/generated/side.cpp
   src/generated/trade.cpp
   include/book.hpp

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -46,7 +46,4 @@ static constexpr char c_instrument_pairs[] = "pairs";
 static constexpr char c_instrument_snapshot[] = "snapshot";
 static constexpr char c_instrument_update[] = "update";
 
-static constexpr char c_metrics_num_bytes[] = "num_bytes";
-static constexpr char c_metrics_num_msgs[] = "num_msgs";
-
 } // namespace kdr

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -31,7 +31,7 @@ struct engine_t final {
   const session_t &session() const { return m_session; }
   session_t &session() { return m_session; }
 
-  void start_processing(const recv_cb_t &cb) { m_session.start_processing(cb); }
+  void start_processing(const recv_cb_t &recv_cb);
   bool keep_processing() const { return m_session.keep_processing(); }
   void stop_processing() {
     m_metrics_timer.cancel();
@@ -44,7 +44,7 @@ struct engine_t final {
 
 private:
   static constexpr auto c_metrics_interval_secs = 10;
-  static constexpr auto c_process_interval_millis = 1;
+  static constexpr auto c_process_interval_micros = 30;
   static constexpr size_t c_process_batch_size = 64;
 
   using doc_t = simdjson::ondemand::document;

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -35,6 +35,7 @@ struct engine_t final {
   bool keep_processing() const { return m_session.keep_processing(); }
   void stop_processing() {
     m_metrics_timer.cancel();
+    m_ping_timer.cancel();
     m_process_timer.cancel();
     m_session.stop_processing();
   }
@@ -61,6 +62,7 @@ private:
   bool handle_pong_msg(doc_t &);
 
   void on_metrics_timer(error_code ec);
+  void on_ping_timer(error_code ec);
   void on_process_timer(error_code ec);
 
   session_t m_session;
@@ -68,13 +70,13 @@ private:
 
   simdjson::ondemand::parser m_parser;
 
-  bool m_subscribed = false;
-
   req_id_t m_book_req_id = 0;
   req_id_t m_inst_req_id = 0;
+  req_id_t m_ping_req_id = 0;
   req_id_t m_trade_req_id = 0;
 
   boost::asio::deadline_timer m_metrics_timer;
+  boost::asio::deadline_timer m_ping_timer;
   boost::asio::steady_timer m_process_timer;
   std::queue<response::book_t> m_book_responses;
 

--- a/include/level_book.hpp
+++ b/include/level_book.hpp
@@ -1,61 +1,11 @@
 #pragma once
 
-#include "book.hpp"
-#include "constants.hpp"
-#include "depth.hpp"
-#include "pair.hpp"
-#include "types.hpp"
+#include "sides.hpp"
 
-#include <boost/crc.hpp>
-#include <boost/json.hpp>
-
-#include <map>
 #include <unordered_map>
 
 namespace kdr {
 namespace model {
-
-using bid_side_t = std::map<price_t, qty_t, std::greater<price_t>>;
-using ask_side_t = std::map<price_t, qty_t, std::less<price_t>>;
-
-struct sides_t final {
-  sides_t(depth_t, integer_t price_precision, integer_t qty_precision,
-          const bid_side_t &, const ask_side_t &);
-
-  depth_t book_depth() const { return m_book_depth; }
-  integer_t price_precision() const { return m_price_precision; }
-  integer_t qty_precision() const { return m_qty_precision; }
-
-  const bid_side_t &bids() const { return m_bids; }
-  const ask_side_t &asks() const { return m_asks; }
-
-  void accept_snapshot(const response::book_t &);
-  void accept_update(const response::book_t &);
-
-  uint64_t crc32() const;
-
-  boost::json::object to_json_obj() const;
-  std::string str() const { return boost::json::serialize(to_json_obj()); }
-
-private:
-  template <typename Q, typename S> void apply_update(const Q &, S &);
-
-  void clear();
-  void verify_checksum(uint64_t) const;
-
-  template <typename S>
-  boost::crc_32_type update_checksum(const boost::crc_32_type, const S &) const;
-
-  depth_t m_book_depth;
-  integer_t m_price_precision = 0;
-  integer_t m_qty_precision = 0;
-
-  bid_side_t m_bids;
-  ask_side_t m_asks;
-
-  std::string m_price_fmt;
-  std::string m_side_fmt;
-};
 
 struct level_book_t final {
   using symbol_t = std::string;
@@ -75,46 +25,6 @@ private:
   depth_t m_book_depth;
   std::unordered_map<symbol_t, sides_t> m_sides;
 };
-
-template <typename S>
-boost::crc_32_type sides_t::update_checksum(boost::crc_32_type crc32,
-                                            const S &side) const {
-  static constexpr size_t c_crc32_depth = 10;
-  auto &result = crc32;
-  auto depth = size_t{0};
-  for (const auto &kv : side) {
-    if (++depth > c_crc32_depth) {
-      break;
-    }
-    const auto &price = kv.first;
-    const auto &qty = kv.second;
-    price.process(crc32, price_precision());
-    qty.process(crc32, qty_precision());
-  }
-  return result;
-}
-
-template <typename Q, typename S>
-void sides_t::apply_update(const Q &quotes, S &side) {
-  for (const auto &quote : quotes) {
-    const auto &[price, qty] = quote;
-    auto it = side.find(price);
-    if (it != side.end()) {
-      if (qty.value() == 0) {
-        side.erase(it);
-      } else {
-        it->second = qty;
-      }
-    } else {
-      side.insert(quote);
-    }
-  }
-  if (side.size() > static_cast<size_t>(m_book_depth)) {
-    auto it = side.begin();
-    std::advance(it, m_book_depth);
-    side.erase(it, side.end());
-  }
-}
 
 } // namespace model
 } // namespace kdr

--- a/include/metrics.hpp
+++ b/include/metrics.hpp
@@ -5,11 +5,27 @@
 #include <boost/json.hpp>
 
 #include <cstddef>
+#include <string_view>
 
 namespace kdr {
 
 struct metrics_t final {
+  static constexpr std::string_view c_num_bytes = "num_bytes";
+  static constexpr std::string_view c_num_msgs = "num_msgs";
+  static constexpr std::string_view c_book_queue_depth = "book_queue_depth";
+  static constexpr std::string_view c_book_last_consumed = "book_last_consumed";
+  static constexpr std::string_view c_num_pings = "num_pings";
+  static constexpr std::string_view c_num_pongs = "num_pongs";
+
   void accept(msg_t);
+
+  void ping() { ++m_num_pings; }
+  void pong() { ++m_num_pongs; }
+
+  void set_book_queue_depth(size_t depth) { m_book_queue_depth = depth; }
+  void set_book_last_consumed(size_t consumed) {
+    m_book_last_consumed = consumed;
+  }
 
   boost::json::object to_json_obj() const;
 
@@ -19,6 +35,10 @@ private:
   const timestamp_t m_stm = timestamp_t::now();
   size_t m_num_msgs = 0;
   size_t m_num_bytes = 0;
+  size_t m_book_queue_depth = 0;
+  size_t m_book_last_consumed = 0;
+  size_t m_num_pings = 0;
+  size_t m_num_pongs = 0;
 };
 
 } // namespace kdr

--- a/include/metrics.hpp
+++ b/include/metrics.hpp
@@ -10,10 +10,12 @@
 namespace kdr {
 
 struct metrics_t final {
+  static constexpr std::string_view c_book_last_consumed = "book_last_consumed";
+  static constexpr std::string_view c_book_last_process_micros =
+      "book_last_process_micros";
+  static constexpr std::string_view c_book_queue_depth = "book_queue_depth";
   static constexpr std::string_view c_num_bytes = "num_bytes";
   static constexpr std::string_view c_num_msgs = "num_msgs";
-  static constexpr std::string_view c_book_queue_depth = "book_queue_depth";
-  static constexpr std::string_view c_book_last_consumed = "book_last_consumed";
   static constexpr std::string_view c_num_pings = "num_pings";
   static constexpr std::string_view c_num_pongs = "num_pongs";
 
@@ -22,10 +24,13 @@ struct metrics_t final {
   void ping() { ++m_num_pings; }
   void pong() { ++m_num_pongs; }
 
-  void set_book_queue_depth(size_t depth) { m_book_queue_depth = depth; }
   void set_book_last_consumed(size_t consumed) {
     m_book_last_consumed = consumed;
   }
+  void set_book_last_process_micros(size_t last_process_micros) {
+    m_book_last_process_micros = last_process_micros;
+  }
+  void set_book_queue_depth(size_t depth) { m_book_queue_depth = depth; }
 
   boost::json::object to_json_obj() const;
 
@@ -33,10 +38,11 @@ struct metrics_t final {
 
 private:
   const timestamp_t m_stm = timestamp_t::now();
-  size_t m_num_msgs = 0;
-  size_t m_num_bytes = 0;
-  size_t m_book_queue_depth = 0;
   size_t m_book_last_consumed = 0;
+  size_t m_book_last_process_micros = 0;
+  size_t m_book_queue_depth = 0;
+  size_t m_num_bytes = 0;
+  size_t m_num_msgs = 0;
   size_t m_num_pings = 0;
   size_t m_num_pongs = 0;
 };

--- a/include/metrics.hpp
+++ b/include/metrics.hpp
@@ -10,17 +10,21 @@
 namespace kdr {
 
 struct metrics_t final {
-  static constexpr std::string_view c_book_last_consumed = "book_last_consumed";
-  static constexpr std::string_view c_book_last_process_micros =
-      "book_last_process_micros";
-  static constexpr std::string_view c_book_queue_depth = "book_queue_depth";
-  static constexpr std::string_view c_num_bytes = "num_bytes";
-  static constexpr std::string_view c_num_msgs = "num_msgs";
-  static constexpr std::string_view c_num_pings = "num_pings";
-  static constexpr std::string_view c_num_pongs = "num_pongs";
+  // clang-format off
+  static constexpr std::string_view c_book_last_consumed       = "book_last_consumed";
+  static constexpr std::string_view c_book_last_process_micros = "book_last_process_micros";
+  static constexpr std::string_view c_book_max_queue_depth     = "book_max_queue_depth";
+  static constexpr std::string_view c_book_queue_depth         = "book_queue_depth";
+  static constexpr std::string_view c_num_bytes                = "num_bytes";
+  static constexpr std::string_view c_num_heartbeats           = "num_heartbeats";
+  static constexpr std::string_view c_num_msgs                 = "num_msgs";
+  static constexpr std::string_view c_num_pings                = "num_pings";
+  static constexpr std::string_view c_num_pongs                = "num_pongs";
+  // clang-format on
 
   void accept(msg_t);
 
+  void heartbeat() { ++m_num_heartbeats; }
   void ping() { ++m_num_pings; }
   void pong() { ++m_num_pongs; }
 
@@ -30,7 +34,11 @@ struct metrics_t final {
   void set_book_last_process_micros(size_t last_process_micros) {
     m_book_last_process_micros = last_process_micros;
   }
-  void set_book_queue_depth(size_t depth) { m_book_queue_depth = depth; }
+  void set_book_queue_depth(size_t depth) {
+    m_book_queue_depth = depth;
+    m_book_max_queue_depth =
+        std::max(m_book_max_queue_depth, m_book_queue_depth);
+  }
 
   boost::json::object to_json_obj() const;
 
@@ -41,7 +49,9 @@ private:
   size_t m_book_last_consumed = 0;
   size_t m_book_last_process_micros = 0;
   size_t m_book_queue_depth = 0;
+  size_t m_book_max_queue_depth = 0;
   size_t m_num_bytes = 0;
+  size_t m_num_heartbeats = 0;
   size_t m_num_msgs = 0;
   size_t m_num_pings = 0;
   size_t m_num_pongs = 0;

--- a/include/sides.hpp
+++ b/include/sides.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "book.hpp"
+#include "constants.hpp"
+#include "depth.hpp"
+#include "pair.hpp"
+#include "types.hpp"
+
+#include <boost/crc.hpp>
+#include <boost/json.hpp>
+
+#include <map>
+#include <unordered_map>
+
+namespace kdr {
+namespace model {
+
+using bid_side_t = std::map<price_t, qty_t, std::greater<price_t>>;
+using ask_side_t = std::map<price_t, qty_t, std::less<price_t>>;
+
+struct sides_t final {
+  sides_t(depth_t, integer_t price_precision, integer_t qty_precision,
+          const bid_side_t &, const ask_side_t &);
+
+  depth_t book_depth() const { return m_book_depth; }
+  integer_t price_precision() const { return m_price_precision; }
+  integer_t qty_precision() const { return m_qty_precision; }
+
+  const bid_side_t &bids() const { return m_bids; }
+  const ask_side_t &asks() const { return m_asks; }
+
+  void accept_snapshot(const response::book_t &);
+  void accept_update(const response::book_t &);
+
+  uint64_t crc32() const;
+
+  boost::json::object to_json_obj() const;
+  std::string str() const { return boost::json::serialize(to_json_obj()); }
+
+private:
+  template <typename Q, typename S> void apply_update(const Q &, S &);
+
+  void clear();
+  void verify_checksum(uint64_t) const;
+
+  template <typename S>
+  boost::crc_32_type update_checksum(const boost::crc_32_type, const S &) const;
+
+  depth_t m_book_depth;
+  integer_t m_price_precision = 0;
+  integer_t m_qty_precision = 0;
+
+  bid_side_t m_bids;
+  ask_side_t m_asks;
+
+  std::string m_price_fmt;
+  std::string m_side_fmt;
+};
+
+template <typename S>
+boost::crc_32_type sides_t::update_checksum(boost::crc_32_type crc32,
+                                            const S &side) const {
+  static constexpr size_t c_crc32_depth = 10;
+  auto &result = crc32;
+  auto depth = size_t{0};
+  for (const auto &kv : side) {
+    if (++depth > c_crc32_depth) {
+      break;
+    }
+    const auto &price = kv.first;
+    const auto &qty = kv.second;
+    price.process(crc32, price_precision());
+    qty.process(crc32, qty_precision());
+  }
+  return result;
+}
+
+template <typename Q, typename S>
+void sides_t::apply_update(const Q &quotes, S &side) {
+  for (const auto &quote : quotes) {
+    const auto &[price, qty] = quote;
+    auto it = side.find(price);
+    if (it != side.end()) {
+      if (qty.value() == 0) {
+        side.erase(it);
+      } else {
+        it->second = qty;
+      }
+    } else {
+      side.insert(quote);
+    }
+  }
+  if (side.size() > static_cast<size_t>(m_book_depth)) {
+    auto it = side.begin();
+    std::advance(it, m_book_depth);
+    side.erase(it, side.end());
+  }
+}
+
+} // namespace model
+} // namespace kdr

--- a/model/pong.json
+++ b/model/pong.json
@@ -1,0 +1,13 @@
+{
+    "class" : "pong",
+
+    "dependencies" : [ "timestamp" ],
+
+    "doc" : "See: https://docs.kraken.com/websockets-v2/#ping",
+
+    "members" : [
+        { "name" : "method",   "type" : "string"    },
+        { "name" : "time_in",  "type" : "timestamp" },
+        { "name" : "time_out", "type" : "timestamp" }
+    ]
+}

--- a/src/level_book.cpp
+++ b/src/level_book.cpp
@@ -2,76 +2,8 @@
 
 #include <boost/log/trivial.hpp>
 
-#include <algorithm>
-#include <string_view>
-
 namespace kdr {
 namespace model {
-
-sides_t::sides_t(depth_t book_depth, integer_t price_precision,
-                 integer_t qty_precision, const bid_side_t &bids,
-                 const ask_side_t &asks)
-    : m_book_depth{book_depth}, m_price_precision(price_precision),
-      m_qty_precision(qty_precision), m_bids{bids}, m_asks{asks} {}
-
-void sides_t::accept_snapshot(const response::book_t &snapshot) {
-  clear();
-  m_bids.insert(snapshot.bids().begin(), snapshot.bids().end());
-  m_asks.insert(snapshot.asks().begin(), snapshot.asks().end());
-  verify_checksum(snapshot.crc32());
-}
-
-void sides_t::accept_update(const response::book_t &update) {
-  apply_update(update.bids(), m_bids);
-  apply_update(update.asks(), m_asks);
-  verify_checksum(update.crc32());
-}
-
-void sides_t::clear() {
-  m_bids.clear();
-  m_asks.clear();
-}
-
-void sides_t::verify_checksum(uint64_t expected_crc32) const {
-  const auto actual_crc32 = crc32();
-  if (expected_crc32 != actual_crc32) {
-    const auto message =
-        "bogus crc32 expected: " + std::to_string(expected_crc32) +
-        " actual: " + std::to_string(actual_crc32);
-    throw std::runtime_error(message);
-  }
-}
-
-uint64_t sides_t::crc32() const {
-  boost::crc_32_type result;
-  result = update_checksum(result, asks());
-  result = update_checksum(result, bids());
-  return result.checksum();
-}
-
-boost::json::object sides_t::to_json_obj() const {
-  auto bid_objs = boost::json::array{};
-  std::transform(
-      bids().begin(), bids().end(), std::back_inserter(bid_objs),
-      [this](const auto &kv) {
-        const boost::json::object quote{
-            {kv.first.str(price_precision()), kv.second.str(qty_precision())}};
-        return quote;
-      });
-
-  auto ask_objs = boost::json::array{};
-  std::transform(
-      asks().begin(), asks().end(), std::back_inserter(ask_objs),
-      [this](const auto &kv) {
-        const boost::json::object quote{
-            {kv.first.str(price_precision()), kv.second.str(qty_precision())}};
-        return quote;
-      });
-
-  const boost::json::object result = {{response::book_t::c_bids, bid_objs},
-                                      {response::book_t::c_asks, ask_objs}};
-  return result;
-}
 
 const sides_t &level_book_t::sides(symbol_t symbol) const {
   const auto it = m_sides.find(symbol);

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -14,8 +14,10 @@ boost::json::object metrics_t::to_json_obj() const {
       {c_num_msgs, m_num_msgs},
       {c_num_bytes, m_num_bytes},
       {c_book_queue_depth, m_book_queue_depth},
+      {c_book_max_queue_depth, m_book_max_queue_depth},
       {c_book_last_consumed, m_book_last_consumed},
       {c_book_last_process_micros, m_book_last_process_micros},
+      {c_num_heartbeats, m_num_heartbeats},
       {c_num_pings, m_num_pings},
       {c_num_pongs, m_num_pongs},
   };

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -15,6 +15,7 @@ boost::json::object metrics_t::to_json_obj() const {
       {c_num_bytes, m_num_bytes},
       {c_book_queue_depth, m_book_queue_depth},
       {c_book_last_consumed, m_book_last_consumed},
+      {c_book_last_process_micros, m_book_last_process_micros},
       {c_num_pings, m_num_pings},
       {c_num_pongs, m_num_pongs},
   };

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -11,8 +11,12 @@ void metrics_t::accept(msg_t msg) {
 
 boost::json::object metrics_t::to_json_obj() const {
   const boost::json::object result = {
-      {c_metrics_num_msgs, m_num_msgs},
-      {c_metrics_num_bytes, m_num_bytes},
+      {c_num_msgs, m_num_msgs},
+      {c_num_bytes, m_num_bytes},
+      {c_book_queue_depth, m_book_queue_depth},
+      {c_book_last_consumed, m_book_last_consumed},
+      {c_num_pings, m_num_pings},
+      {c_num_pongs, m_num_pongs},
   };
   return result;
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -16,18 +16,10 @@ namespace ws = bst::websocket;
 namespace kdr {
 
 session_t::session_t(ssl_context_t &ssl_context, const config_t &config)
-    : m_resolver{m_ioc}, m_ws{m_ioc, ssl_context}, m_ping_timer{m_ioc},
-      m_config{config} {
-  if (m_config.ping_interval_secs() < 1) {
-    BOOST_LOG_TRIVIAL(error)
-        << __FUNCTION__
-        << " ping_interval_secs (=" << m_config.ping_interval_secs()
-        << ") must be at least one";
-  }
-}
+    : m_resolver{m_ioc}, m_ws{m_ioc, ssl_context}, m_config{config} {}
 
 void session_t::fail(bst::error_code ec, char const *what) {
-  BOOST_LOG_TRIVIAL(error) << what << ": " << ec.message();
+  BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << what << ": " << ec.message();
   m_keep_processing = false;
 }
 
@@ -38,6 +30,9 @@ void session_t::start_processing(const connected_cb_t &handle_connected,
   m_keep_processing = true;
   m_resolver.async_resolve(m_config.kraken_host(), m_config.kraken_port(),
                            [this](error_code ec, resolver::results_type rt) {
+                             if (!ec) {
+                               BOOST_LOG_TRIVIAL(info) << "resolve suceeded";
+                             }
                              this->on_resolve(ec, rt);
                            });
 }
@@ -49,20 +44,19 @@ void session_t::send(msg_t msg) {
                    [this, msg_str = std::move(msg_str)](
                        error_code ec, size_t num_bytes_written) {
                      if (ec) {
-                       fail(ec, __FUNCTION__);
+                       fail(ec, "session_t::send async_write failed");
                      }
                      if (num_bytes_written != msg_str->size()) {
                        const std::string message =
                            std::string(__FUNCTION__) + " short write: " +
                            "expected: " + std::to_string(msg_str->size()) +
                            " actual: " + std::to_string(num_bytes_written);
-                       throw std::runtime_error(message);
+                       fail(ec, message.c_str());
                      }
                    });
 }
 
 void session_t::on_resolve(error_code ec, resolver::results_type results) {
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " entered";
   if (ec) {
     fail(ec, __FUNCTION__);
   }
@@ -71,15 +65,15 @@ void session_t::on_resolve(error_code ec, resolver::results_type results) {
   boost::beast::get_lowest_layer(m_ws).async_connect(
       results,
       [this](error_code ec, resolver::results_type::endpoint_type endpoint) {
+        if (!ec) {
+          BOOST_LOG_TRIVIAL(info) << "connect succeeded";
+        }
         this->on_connect(ec, endpoint);
       });
-
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " succeeded";
 }
 
 void session_t::on_connect(error_code ec,
                            resolver::results_type::endpoint_type endpoint) {
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " entered";
   if (ec) {
     fail(ec, __FUNCTION__);
   }
@@ -96,14 +90,15 @@ void session_t::on_connect(error_code ec,
 
   host += ':' + std::to_string(endpoint.port());
   m_ws.next_layer().async_handshake(
-      asio::ssl::stream_base::client,
-      [this](error_code ec) { this->on_ssl_handshake(ec); });
-
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " succeeded";
+      asio::ssl::stream_base::client, [this](error_code ec) {
+        if (!ec) {
+          BOOST_LOG_TRIVIAL(info) << "ssl handshake succeeded";
+        }
+        this->on_ssl_handshake(ec);
+      });
 }
 
 void session_t::on_ssl_handshake(error_code ec) {
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " entered";
   if (ec) {
     fail(ec, __FUNCTION__);
   }
@@ -119,10 +114,12 @@ void session_t::on_ssl_handshake(error_code ec) {
                 " websocket-client-async-ssl");
   }));
 
-  m_ws.async_handshake(m_config.kraken_host(), "/v2",
-                       [this](error_code ec) { this->on_handshake(ec); });
-
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " succeeded";
+  m_ws.async_handshake(m_config.kraken_host(), "/v2", [this](error_code ec) {
+    if (!ec) {
+      BOOST_LOG_TRIVIAL(info) << "handshake succeeded";
+    }
+    this->on_handshake(ec);
+  });
 }
 
 void session_t::on_handshake(error_code ec) {
@@ -130,45 +127,14 @@ void session_t::on_handshake(error_code ec) {
     fail(ec, __FUNCTION__);
   }
 
+  m_keep_processing = true;
+
   m_handle_connected();
 
-  m_keep_processing = true;
   m_read_buffer.clear();
   m_ws.async_read(m_read_buffer, [this](error_code ec, size_t size) {
     this->on_read(ec, size);
   });
-
-  m_ping_timer.expires_from_now(
-      boost::posix_time::seconds(m_config.ping_interval_secs()));
-  m_ping_timer.async_wait([this](error_code ec) { this->on_ping_timer(ec); });
-}
-
-void session_t::on_ping_timer(error_code ec) {
-  if (ec) {
-    fail(ec, __FUNCTION__);
-  }
-
-  if (!m_keep_processing) {
-    BOOST_LOG_TRIVIAL(debug)
-        << __FUNCTION__
-        << " returning -  m_keep_processing: " << m_keep_processing;
-    ;
-    return;
-  }
-
-  try {
-    const auto ping = request::ping_t{++m_req_id};
-    const auto msg = ping.str();
-    send(msg);
-
-    m_ping_timer.expires_from_now(
-        boost::posix_time::seconds(m_config.ping_interval_secs()));
-    m_ping_timer.async_wait([this](error_code ec) { this->on_ping_timer(ec); });
-
-  } catch (const std::exception &ex) {
-    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << " " << ex.what();
-    m_keep_processing = false;
-  }
 }
 
 void session_t::on_write(error_code ec, size_t size) {
@@ -183,33 +149,25 @@ void session_t::on_read(error_code ec, size_t size) {
     fail(ec, __FUNCTION__);
   }
 
-  try {
-    // !@# TODO - see whether we can eliminate this copy by connecting
-    // simdjson's iterator directly to buffer sequence
-    m_read_msg_str = boost::beast::buffers_to_string(m_read_buffer.data());
-    if (m_read_msg_str.size() != size) {
-      BOOST_LOG_TRIVIAL(error)
-          << __FUNCTION__ << "read expected size: " << size
-          << " but received size: " << m_read_msg_str.size();
-      stop_processing();
-      return;
-    }
-    if (size == 0) {
-      // !@# TODO: count number of occurrances and escalate if they accumulate
-      BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": received empty message";
-      return;
-    }
-    //    m_read_buffer.consume(size);
-    m_read_buffer.consume(m_read_msg_str.size());
-    if (!m_handle_recv(std::string_view(m_read_msg_str))) {
-      BOOST_LOG_TRIVIAL(error)
-          << __FUNCTION__ << "handle_recv() returned false -- stop processing";
-      stop_processing();
-      return;
-    }
-  } catch (const std::exception &ex) {
-    BOOST_LOG_TRIVIAL(error) << ex.what();
-    BOOST_LOG_TRIVIAL(error) << "msg: " << m_read_msg_str;
+  // !@# TODO - see whether we can eliminate this copy by connecting
+  // simdjson's iterator directly to buffer sequence
+  m_read_msg_str = boost::beast::buffers_to_string(m_read_buffer.data());
+  if (m_read_msg_str.size() != size) {
+    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "read expected size: " << size
+                             << " but received size: " << m_read_msg_str.size();
+    stop_processing();
+    return;
+  }
+
+  if (size == 0) {
+    BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": received empty message";
+    return;
+  }
+  m_read_buffer.consume(m_read_msg_str.size());
+
+  if (!m_handle_recv(std::string_view(m_read_msg_str))) {
+    BOOST_LOG_TRIVIAL(error)
+        << __FUNCTION__ << "handle_recv() returned false -- stop processing";
     stop_processing();
     return;
   }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -31,7 +31,9 @@ void session_t::fail(bst::error_code ec, char const *what) {
   m_keep_processing = false;
 }
 
-void session_t::start_processing(const recv_cb_t &handle_recv) {
+void session_t::start_processing(const connected_cb_t &handle_connected,
+                                 const recv_cb_t &handle_recv) {
+  m_handle_connected = handle_connected;
   m_handle_recv = handle_recv;
   m_keep_processing = true;
   m_resolver.async_resolve(m_config.kraken_host(), m_config.kraken_port(),
@@ -124,12 +126,12 @@ void session_t::on_ssl_handshake(error_code ec) {
 }
 
 void session_t::on_handshake(error_code ec) {
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " entered";
   if (ec) {
     fail(ec, __FUNCTION__);
   }
 
-  BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << " succeeded";
+  m_handle_connected();
+
   m_keep_processing = true;
   m_read_buffer.clear();
   m_ws.async_read(m_read_buffer, [this](error_code ec, size_t size) {

--- a/src/sides.cpp
+++ b/src/sides.cpp
@@ -1,0 +1,77 @@
+#include "sides.hpp"
+
+#include <boost/log/trivial.hpp>
+
+#include <algorithm>
+#include <string_view>
+
+namespace kdr {
+namespace model {
+
+sides_t::sides_t(depth_t book_depth, integer_t price_precision,
+                 integer_t qty_precision, const bid_side_t &bids,
+                 const ask_side_t &asks)
+    : m_book_depth{book_depth}, m_price_precision(price_precision),
+      m_qty_precision(qty_precision), m_bids{bids}, m_asks{asks} {}
+
+void sides_t::accept_snapshot(const response::book_t &snapshot) {
+  clear();
+  m_bids.insert(snapshot.bids().begin(), snapshot.bids().end());
+  m_asks.insert(snapshot.asks().begin(), snapshot.asks().end());
+  verify_checksum(snapshot.crc32());
+}
+
+void sides_t::accept_update(const response::book_t &update) {
+  apply_update(update.bids(), m_bids);
+  apply_update(update.asks(), m_asks);
+  verify_checksum(update.crc32());
+}
+
+void sides_t::clear() {
+  m_bids.clear();
+  m_asks.clear();
+}
+
+void sides_t::verify_checksum(uint64_t expected_crc32) const {
+  const auto actual_crc32 = crc32();
+  if (expected_crc32 != actual_crc32) {
+    const auto message =
+        "bogus crc32 expected: " + std::to_string(expected_crc32) +
+        " actual: " + std::to_string(actual_crc32);
+    throw std::runtime_error(message);
+  }
+}
+
+uint64_t sides_t::crc32() const {
+  boost::crc_32_type result;
+  result = update_checksum(result, asks());
+  result = update_checksum(result, bids());
+  return result.checksum();
+}
+
+boost::json::object sides_t::to_json_obj() const {
+  auto bid_objs = boost::json::array{};
+  std::transform(
+      bids().begin(), bids().end(), std::back_inserter(bid_objs),
+      [this](const auto &kv) {
+        const boost::json::object quote{
+            {kv.first.str(price_precision()), kv.second.str(qty_precision())}};
+        return quote;
+      });
+
+  auto ask_objs = boost::json::array{};
+  std::transform(
+      asks().begin(), asks().end(), std::back_inserter(ask_objs),
+      [this](const auto &kv) {
+        const boost::json::object quote{
+            {kv.first.str(price_precision()), kv.second.str(qty_precision())}};
+        return quote;
+      });
+
+  const boost::json::object result = {{response::book_t::c_bids, bid_objs},
+                                      {response::book_t::c_asks, ask_objs}};
+  return result;
+}
+
+} // namespace model
+} // namespace kdr


### PR DESCRIPTION
Revamp session and engine:
- move ping logic up into engine
- introduce work queue and service it outside the read callback
- expand metrics